### PR TITLE
Add dataset validation and contributor tooling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,35 @@
+name: Bug report
+description: Report a problem with the browser, setup guide, scripts, or documentation.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Include the browser, command, or file you used.
+      placeholder: |
+        1. Open index.html
+        2. Search for ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: "Chrome 126, macOS 15 / Node 20"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/data_issue.yml
+++ b/.github/ISSUE_TEMPLATE/data_issue.yml
@@ -1,0 +1,29 @@
+name: Data issue
+description: Report an exercise metadata, instruction, translation, or media-reference problem.
+title: "[Data]: "
+labels:
+  - data
+body:
+  - type: input
+    id: exercise-id
+    attributes:
+      label: Exercise ID
+      description: The `id` from `data/exercises.json`, if known.
+      placeholder: "0001"
+  - type: input
+    id: exercise-name
+    attributes:
+      label: Exercise name
+      placeholder: "3/4 sit-up"
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe what is wrong and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested fix
+      description: Optional. Include source or reasoning if you know the correct value.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+- Describe the change and why it is needed.
+
+## Type of change
+
+- [ ] Dataset change
+- [ ] Documentation change
+- [ ] Tooling / validation change
+- [ ] Browser UI change
+- [ ] Example / integration change
+
+## Validation
+
+- [ ] I ran `node scripts/validate-dataset.mjs`
+- [ ] I preserved Gym visual attribution and media-license requirements
+- [ ] I manually checked affected browser pages, if applicable
+
+## Notes for reviewers
+
+- Include any review context, follow-up work, or known limitations.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,33 @@
+name: Validate dataset
+
+on:
+  push:
+    paths:
+      - data/exercises.json
+      - images/**
+      - videos/**
+      - scripts/validate-dataset.mjs
+      - .github/workflows/validate.yml
+  pull_request:
+    paths:
+      - data/exercises.json
+      - images/**
+      - videos/**
+      - scripts/validate-dataset.mjs
+      - .github/workflows/validate.yml
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Validate exercises dataset
+        run: node scripts/validate-dataset.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+Thanks for helping improve the exercises dataset. Keep changes small, reviewable, and focused on data quality, tooling, or documentation.
+
+## Before opening a PR
+
+1. Confirm your change is allowed by the media license in `LICENSE` and `NOTICE.md`.
+2. Run the dataset validator:
+
+   ```bash
+   node scripts/validate-dataset.mjs
+   ```
+
+3. If you are changing schema or validation behavior, check open pull requests first to avoid duplicating active work.
+
+## Dataset rules
+
+- Keep every exercise `id` unique and formatted as four digits, for example `0001`.
+- Keep `image` and `gif_url` paths aligned with `id` and `media_id`:
+  - `images/<id>-<media_id>.jpg`
+  - `videos/<id>-<media_id>.gif`
+- Keep all six instruction languages populated: `en`, `es`, `it`, `tr`, `ru`, and `zh`.
+- Keep both `instructions` and `instruction_steps` in sync when editing exercise instructions.
+- Keep `secondary_muscles` as an array of strings.
+- Keep the exact media attribution in every record: `© Gym visual — https://gymvisual.com/`.
+
+Duplicate exercise names are allowed only when the records represent distinct media or movement variants. The validator reports them as warnings so reviewers can inspect them.
+
+## Media rules
+
+The `images/` and `videos/` assets are not covered by the MIT license. They are included with separate permission from Gym visual at 180x180 resolution. Do not replace, upscale, redistribute, or add media unless you have confirmed the rights and attribution requirements.
+
+## Browser checks
+
+If you edit `index.html`, manually verify:
+
+- Search filters the exercise grid.
+- Category, equipment, and target filters work.
+- Infinite scroll appends more exercises.
+- Exercise modals show media, metadata, muscles, and language tabs.
+
+If you edit `setup.html`, manually verify:
+
+- Database tabs switch SQL dialects.
+- SQL generation downloads a file.
+- API language tabs update examples.
+- The LLM prompt updates when framework or database options change.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 - [Data Schema](#-data-schema)
 - [Sample Exercises](#-sample-exercises)
 - [Usage Examples](#-usage-examples)
+- [Contributing](#-contributing)
 - [License & Use](#-license--use)
 
 ---
@@ -106,10 +107,15 @@ A step-by-step guide for integrating the dataset into your own application:
 exercises-dataset/
 ├── data/
 │   └── exercises.json       # Full dataset — 1,324 exercise records (JSON array)
+├── examples/                # Small Node, Python, and SQLite integration examples
+├── scripts/
+│   └── validate-dataset.mjs # Dataset and media integrity validator
 ├── images/                  # 1,324 × 180×180 thumbnails  (© Gym visual)
 ├── videos/                  # 1,324 × 180×180 animation GIFs  (© Gym visual)
+├── .github/                 # CI workflow and issue / PR templates
 ├── index.html               # Interactive exercise browser (client-side, no server needed)
 ├── setup.html               # Developer setup guide (DB import + API integration)
+├── CONTRIBUTING.md          # Contribution and validation rules
 ├── NOTICE.md                # Media attribution & license terms
 └── README.md
 ```
@@ -117,6 +123,8 @@ exercises-dataset/
 ### Key Files
 
 - **`data/exercises.json`** — The primary data file. A JSON array of 1,324 exercise objects with all metadata. `image` / `gif_url` point to the local 180×180 assets, and each record carries an `attribution` field; `media_id` holds the original media reference id.
+- **`scripts/validate-dataset.mjs`** — Dependency-free validation for dataset structure, multilingual instructions, duplicate IDs, and media references.
+- **`examples/`** — Small integration examples for loading the dataset from Node.js, Python, and SQLite.
 - **`images/`, `videos/`** — 180×180 thumbnails and animation GIFs (© [Gym visual](https://gymvisual.com/), used with permission).
 - **`index.html`** — Standalone exercise browser. Open directly in any modern browser.
 - **`setup.html`** — Developer guide for DB setup, API integration, and LLM-assisted backend generation.
@@ -184,6 +192,7 @@ Each record in `data/exercises.json` follows this structure:
 | `instructions.tr` | `string` | Full step-by-step instructions in Turkish |
 | `instructions.ru` | `string` | Full step-by-step instructions in Russian |
 | `instructions.zh` | `string` | Full step-by-step instructions in Chinese |
+| `instruction_steps` | `object<string, string[]>` | Step arrays for each supported language (`en`, `es`, `it`, `tr`, `ru`, `zh`) |
 | `muscle_group` | `string` | Primary synergist muscle group |
 | `secondary_muscles` | `array[string]` | Additional muscles involved |
 | `target` | `string` | Primary target muscle (e.g. `"biceps"`, `"pectoralis major"`) |
@@ -209,6 +218,17 @@ Each record in `data/exercises.json` follows this structure:
     "tr": "Sırt üstü yatın, dizlerinizi bükün ve ayaklarınızı yere düz koyun. ...",
     "ru": "Лягте на спину, согните колени и поставьте ступни на землю. ...",
     "zh": "平躺，膝盖弯曲，双脚平放在地上。..."
+  },
+  "instruction_steps": {
+    "en": [
+      "Lie flat on your back with your knees bent and feet flat on the ground.",
+      "Place your hands behind your head with your elbows pointing outwards."
+    ],
+    "es": ["Túmbate sobre tu espalda con las rodillas flexionadas y los pies apoyados en el suelo. ..."],
+    "it": ["Sdraiati sulla schiena con le ginocchia piegate e i piedi appoggiati a terra. ..."],
+    "tr": ["Sırt üstü yatın, dizlerinizi bükün ve ayaklarınızı yere düz koyun. ..."],
+    "ru": ["Лягте на спину, согните колени и поставьте ступни на землю. ..."],
+    "zh": ["平躺，膝盖弯曲，双脚平放在地上。..."]
   },
   "muscle_group": "hip flexors",
   "secondary_muscles": ["hip flexors", "lower back"],
@@ -390,6 +410,14 @@ interface Exercise {
     ru: string;
     zh: string;
   };
+  instruction_steps: {
+    en: string[];
+    es: string[];
+    it: string[];
+    tr: string[];
+    ru: string[];
+    zh: string[];
+  };
   muscle_group: string;
   secondary_muscles: string[];
   target: string;
@@ -406,6 +434,20 @@ const data = exercises as Exercise[];
 const randomWorkout: Exercise[] = data.slice(0, 6);
 console.log("First 6 exercises:", randomWorkout.map(e => e.name));
 ```
+
+---
+
+## 🤝 Contributing
+
+Before opening a pull request, run the dataset validator:
+
+```bash
+node scripts/validate-dataset.mjs
+```
+
+The validator checks JSON structure, required fields, multilingual instructions, duplicate IDs, media references, missing media files, and orphan media files. Duplicate exercise names are reported as warnings because some records may represent distinct movement or media variants.
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for dataset rules, media-license requirements, and browser verification notes.
 
 ---
 

--- a/examples/node-load-dataset.mjs
+++ b/examples/node-load-dataset.mjs
@@ -1,0 +1,27 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const dataPath = path.resolve(__dirname, '..', 'data', 'exercises.json');
+
+const exercises = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+
+const byBodyPart = exercises.reduce((counts, exercise) => {
+  counts[exercise.body_part] = (counts[exercise.body_part] ?? 0) + 1;
+  return counts;
+}, {});
+
+const bodyweight = exercises.filter((exercise) => exercise.equipment === 'body weight');
+
+console.log(`Total exercises: ${exercises.length}`);
+console.log(`Bodyweight exercises: ${bodyweight.length}`);
+console.log('Exercises by body part:');
+
+for (const [bodyPart, count] of Object.entries(byBodyPart).sort((a, b) => b[1] - a[1])) {
+  console.log(`- ${bodyPart}: ${count}`);
+}
+
+console.log('\nFirst exercise media attribution:');
+console.log(exercises[0].attribution);

--- a/examples/python-load-dataset.py
+++ b/examples/python-load-dataset.py
@@ -1,0 +1,27 @@
+import json
+from collections import Counter
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA_PATH = ROOT / "data" / "exercises.json"
+
+
+with DATA_PATH.open(encoding="utf-8") as file:
+    exercises = json.load(file)
+
+by_body_part = Counter(exercise["body_part"] for exercise in exercises)
+bodyweight = [
+    exercise for exercise in exercises
+    if exercise["equipment"] == "body weight"
+]
+
+print(f"Total exercises: {len(exercises)}")
+print(f"Bodyweight exercises: {len(bodyweight)}")
+print("Exercises by body part:")
+
+for body_part, count in by_body_part.most_common():
+    print(f"- {body_part}: {count}")
+
+print("\nFirst exercise media attribution:")
+print(exercises[0]["attribution"])

--- a/examples/sqlite-import.md
+++ b/examples/sqlite-import.md
@@ -1,0 +1,51 @@
+# SQLite import example
+
+The dataset can be imported into SQLite by storing multilingual instructions and secondary muscles as JSON text columns.
+
+## Minimal table
+
+```sql
+CREATE TABLE exercises (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  category TEXT,
+  body_part TEXT,
+  equipment TEXT,
+  instructions TEXT,
+  instruction_steps TEXT,
+  muscle_group TEXT,
+  secondary_muscles TEXT,
+  target TEXT,
+  image TEXT,
+  gif_url TEXT,
+  media_id TEXT,
+  created_at TEXT,
+  attribution TEXT
+);
+```
+
+## Generate INSERT statements
+
+Open `setup.html`, choose the SQLite tab, and click "Generate INSERT SQL". The generated file contains all 1,324 records and can be imported with:
+
+```bash
+sqlite3 exercises.db < exercises_insert_sqlite.sql
+```
+
+## Query examples
+
+```sql
+SELECT COUNT(*) FROM exercises;
+
+SELECT name, target, equipment
+FROM exercises
+WHERE equipment = 'body weight'
+ORDER BY name
+LIMIT 20;
+
+SELECT name, json_extract(instructions, '$.en') AS english_instructions
+FROM exercises
+WHERE id = '0001';
+```
+
+The media paths in `image` and `gif_url` point to files in this repository. Keep the `attribution` value with any exported records that include media references.

--- a/scripts/validate-dataset.mjs
+++ b/scripts/validate-dataset.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+
+const dataPath = path.join(rootDir, 'data', 'exercises.json');
+const imageDir = path.join(rootDir, 'images');
+const videoDir = path.join(rootDir, 'videos');
+
+const LANGUAGES = ['en', 'es', 'it', 'tr', 'ru', 'zh'];
+const REQUIRED_FIELDS = [
+  'id',
+  'name',
+  'category',
+  'body_part',
+  'equipment',
+  'instructions',
+  'instruction_steps',
+  'muscle_group',
+  'secondary_muscles',
+  'target',
+  'image',
+  'gif_url',
+  'media_id',
+  'created_at',
+  'attribution',
+];
+const EXPECTED_ATTRIBUTION = '\u00a9 Gym visual \u2014 https://gymvisual.com/';
+
+const errors = [];
+const warnings = [];
+const stats = {
+  missingRequiredFields: 0,
+  missingLanguageInstructions: 0,
+  duplicateIds: 0,
+  duplicateNames: 0,
+  missingMediaFiles: 0,
+  orphanMediaFiles: 0,
+};
+
+function relative(filePath) {
+  return path.relative(rootDir, filePath).replaceAll(path.sep, '/');
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    errors.push(`Could not parse ${relative(filePath)}: ${error.message}`);
+    return null;
+  }
+}
+
+function listFiles(dir, extension) {
+  if (!fs.existsSync(dir)) {
+    errors.push(`Missing directory: ${relative(dir)}`);
+    return [];
+  }
+
+  return fs.readdirSync(dir)
+    .filter((fileName) => fileName.endsWith(extension))
+    .map((fileName) => path.posix.join(relative(dir), fileName));
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function countDuplicates(values) {
+  const counts = new Map();
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
+  return [...counts.entries()].filter(([, count]) => count > 1);
+}
+
+function addMissingFieldError(record, field) {
+  stats.missingRequiredFields += 1;
+  errors.push(`Record ${record.id ?? '<unknown>'} is missing required field "${field}"`);
+}
+
+function validateLanguageMaps(record) {
+  for (const lang of LANGUAGES) {
+    if (!isNonEmptyString(record.instructions?.[lang])) {
+      stats.missingLanguageInstructions += 1;
+      errors.push(`Record ${record.id} is missing instructions.${lang}`);
+    }
+
+    const steps = record.instruction_steps?.[lang];
+    if (!Array.isArray(steps) || steps.length === 0 || steps.some((step) => !isNonEmptyString(step))) {
+      stats.missingLanguageInstructions += 1;
+      errors.push(`Record ${record.id} is missing valid instruction_steps.${lang}`);
+    }
+  }
+}
+
+function validateRecord(record, index) {
+  if (typeof record !== 'object' || record === null || Array.isArray(record)) {
+    errors.push(`Entry at index ${index} is not an object`);
+    return;
+  }
+
+  for (const field of REQUIRED_FIELDS) {
+    if (!(field in record) || record[field] === null || record[field] === '') {
+      addMissingFieldError(record, field);
+    }
+  }
+
+  if (!/^\d{4}$/.test(record.id ?? '')) {
+    errors.push(`Record ${record.id ?? `<index ${index}>`} has invalid id format`);
+  }
+
+  for (const field of ['name', 'category', 'body_part', 'equipment', 'muscle_group', 'target', 'media_id']) {
+    if (!isNonEmptyString(record[field])) {
+      errors.push(`Record ${record.id ?? `<index ${index}>`} has invalid ${field}`);
+    }
+  }
+
+  if (!Array.isArray(record.secondary_muscles) || record.secondary_muscles.some((muscle) => !isNonEmptyString(muscle))) {
+    errors.push(`Record ${record.id} has invalid secondary_muscles`);
+  }
+
+  validateLanguageMaps(record);
+
+  const expectedImage = `images/${record.id}-${record.media_id}.jpg`;
+  const expectedGif = `videos/${record.id}-${record.media_id}.gif`;
+
+  if (record.image !== expectedImage) {
+    errors.push(`Record ${record.id} image should be "${expectedImage}", got "${record.image}"`);
+  }
+
+  if (record.gif_url !== expectedGif) {
+    errors.push(`Record ${record.id} gif_url should be "${expectedGif}", got "${record.gif_url}"`);
+  }
+
+  if (record.attribution !== EXPECTED_ATTRIBUTION) {
+    errors.push(`Record ${record.id} has invalid media attribution`);
+  }
+
+  if (!isNonEmptyString(record.created_at) || Number.isNaN(Date.parse(record.created_at))) {
+    errors.push(`Record ${record.id} has invalid created_at timestamp`);
+  }
+}
+
+function validateMediaReferences(records) {
+  const imageRefs = new Set(records.map((record) => record.image).filter(Boolean));
+  const gifRefs = new Set(records.map((record) => record.gif_url).filter(Boolean));
+  const imageFiles = listFiles(imageDir, '.jpg');
+  const gifFiles = listFiles(videoDir, '.gif');
+  const imageFileSet = new Set(imageFiles);
+  const gifFileSet = new Set(gifFiles);
+
+  const missingImages = [...imageRefs].filter((filePath) => !imageFileSet.has(filePath));
+  const missingGifs = [...gifRefs].filter((filePath) => !gifFileSet.has(filePath));
+  const orphanImages = imageFiles.filter((filePath) => !imageRefs.has(filePath));
+  const orphanGifs = gifFiles.filter((filePath) => !gifRefs.has(filePath));
+
+  stats.missingMediaFiles = missingImages.length + missingGifs.length;
+  stats.orphanMediaFiles = orphanImages.length + orphanGifs.length;
+
+  for (const filePath of missingImages) errors.push(`Missing image file referenced by dataset: ${filePath}`);
+  for (const filePath of missingGifs) errors.push(`Missing GIF file referenced by dataset: ${filePath}`);
+  for (const filePath of orphanImages) errors.push(`Orphan image file not referenced by dataset: ${filePath}`);
+  for (const filePath of orphanGifs) errors.push(`Orphan GIF file not referenced by dataset: ${filePath}`);
+
+  return { imageFiles, gifFiles };
+}
+
+function main() {
+  const records = readJson(dataPath);
+  if (!records) return 1;
+
+  if (!Array.isArray(records)) {
+    errors.push('data/exercises.json must contain a JSON array');
+    return 1;
+  }
+
+  records.forEach(validateRecord);
+
+  const duplicateIds = countDuplicates(records.map((record) => record.id));
+  const duplicateNames = countDuplicates(records.map((record) => record.name));
+  stats.duplicateIds = duplicateIds.length;
+  stats.duplicateNames = duplicateNames.length;
+
+  for (const [id, count] of duplicateIds) {
+    errors.push(`Duplicate id "${id}" appears ${count} times`);
+  }
+
+  for (const [name, count] of duplicateNames) {
+    warnings.push(`Duplicate exercise name "${name}" appears ${count} times`);
+  }
+
+  const { imageFiles, gifFiles } = validateMediaReferences(records);
+
+  console.log('Dataset validation');
+  console.log(`Records: ${records.length}`);
+  console.log(`Images: ${imageFiles.length}`);
+  console.log(`GIFs: ${gifFiles.length}`);
+  console.log(`Missing required fields: ${stats.missingRequiredFields}`);
+  console.log(`Missing language instructions: ${stats.missingLanguageInstructions}`);
+  console.log(`Duplicate IDs: ${stats.duplicateIds}`);
+  console.log(`Missing media files: ${stats.missingMediaFiles}`);
+  console.log(`Orphan media files: ${stats.orphanMediaFiles}`);
+  console.log(`Duplicate-name warnings: ${stats.duplicateNames}`);
+  console.log(`Warnings: ${warnings.length}`);
+
+  if (errors.length > 0) {
+    console.error('\nValidation failed:');
+    for (const error of errors) console.error(`- ${error}`);
+    return 1;
+  }
+
+  if (warnings.length > 0) {
+    console.log('\nValidation warnings:');
+    for (const warning of warnings) console.log(`- ${warning}`);
+  }
+
+  console.log('Validation passed');
+  return 0;
+}
+
+process.exitCode = main();

--- a/setup.html
+++ b/setup.html
@@ -1638,6 +1638,32 @@ renderApiCode();
 const llmPromptBox  = document.getElementById('llm-prompt');
 const copyPromptBtn = document.getElementById('copy-prompt-btn');
 
+function setCopyPromptButtonDefault() {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('width', '14');
+  svg.setAttribute('height', '14');
+  svg.setAttribute('viewBox', '0 0 16 16');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '1.8');
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('stroke-linejoin', 'round');
+
+  const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+  rect.setAttribute('x', '4');
+  rect.setAttribute('y', '4');
+  rect.setAttribute('width', '9');
+  rect.setAttribute('height', '11');
+  rect.setAttribute('rx', '1.5');
+
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M11 4V3a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h1');
+
+  svg.appendChild(rect);
+  svg.appendChild(path);
+  copyPromptBtn.replaceChildren(svg, document.createTextNode(' Copy Prompt'));
+}
+
 function renderLlmPrompt() {
   llmPromptBox.value = buildLlmPrompt(currentFw, currentLlmDb);
 }
@@ -1665,7 +1691,7 @@ copyPromptBtn.addEventListener('click', () => {
     copyPromptBtn.textContent = '✓ Copied!';
     copyPromptBtn.classList.add('copied');
     setTimeout(() => {
-      copyPromptBtn.innerHTML = `<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="9" height="11" rx="1.5"/><path d="M11 4V3a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h1"/></svg> Copy Prompt`;
+      setCopyPromptButtonDefault();
       copyPromptBtn.classList.remove('copied');
     }, 2500);
   });


### PR DESCRIPTION
## Summary

Adds contributor-focused maintenance infrastructure for the exercises dataset:

- dependency-free dataset validator for required fields, language coverage, duplicate IDs, media references, orphan media, and duplicate-name warnings
- GitHub Actions workflow to run validation on dataset/media/tooling changes
- contribution guide, PR template, and issue templates
- README updates for validation, examples, and `instruction_steps`
- safer browser rendering by removing dataset-derived `innerHTML` paths in `index.html` and `setup.html`
- small Node, Python, and SQLite usage examples

## Notes

I did not add a competing JSON Schema file because there is already an open upstream PR for that work: #34.

## Validation

- `node --check scripts/validate-dataset.mjs`
- `node --check examples/node-load-dataset.mjs`
- `node scripts/validate-dataset.mjs`
- `node examples/node-load-dataset.mjs`
- `python3 examples/python-load-dataset.py`
- `git diff --check HEAD~1..HEAD`
- Headless browser smoke test for `index.html` and `setup.html`

Validator result:

- 1,324 records
- 1,324 images
- 1,324 GIFs
- 0 missing required fields
- 0 missing language instructions
- 0 duplicate IDs
- 0 missing media files
- 0 orphan media files
- 6 duplicate-name warnings, reported without failing validation
