### PR TITLE
Add dataset validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,39 @@
+name: Validate dataset
+
+on:
+  push:
+    paths:
+      - data/exercises.json
+      - images/**
+      - videos/**
+      - scripts/validate-dataset.mjs
+      - .github/workflows/validate.yml
+  pull_request:
+    paths:
+      - data/exercises.json
+      - images/**
+      - videos/**
+      - scripts/validate-dataset.mjs
+      - .github/workflows/validate.yml
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Validate exercises dataset
+        run: |
+          if [ ! -f scripts/validate-dataset.mjs ]; then
+            echo "Validator script is not present yet. Merge the validator PR first."
+            exit 0
+          fi
+
+          node scripts/validate-dataset.mjs


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs dataset validation when dataset, media, validator, or workflow files change.

## Dependency

This is split from the validator work for review clarity. Merge after #36 so `scripts/validate-dataset.mjs` is present on `main`.

Until then, the workflow exits successfully with a clear message if the validator script is missing.

## Validation

- `git diff --check HEAD~1..HEAD`
