### PR TITLE
Add hi, pl, ko to JSON Schema language maps

### DIFF
--- a/data/exercises.schema.json
+++ b/data/exercises.schema.json
@@ -17,9 +17,12 @@
         "it": { "type": "string" },
         "tr": { "type": "string" },
         "ru": { "type": "string" },
-        "zh": { "type": "string" }
+        "zh": { "type": "string" },
+        "hi": { "type": "string" },
+        "pl": { "type": "string" },
+        "ko": { "type": "string" }
       },
-      "required": ["en", "es", "it", "tr", "ru", "zh"],
+      "required": ["en", "es", "it", "tr", "ru", "zh", "hi", "pl", "ko"],
       "additionalProperties": { "type": "string" }
     },
     "languageStepsMap": {
@@ -31,9 +34,12 @@
         "it": { "$ref": "#/$defs/steps" },
         "tr": { "$ref": "#/$defs/steps" },
         "ru": { "$ref": "#/$defs/steps" },
-        "zh": { "$ref": "#/$defs/steps" }
+        "zh": { "$ref": "#/$defs/steps" },
+        "hi": { "$ref": "#/$defs/steps" },
+        "pl": { "$ref": "#/$defs/steps" },
+        "ko": { "$ref": "#/$defs/steps" }
       },
-      "required": ["en", "es", "it", "tr", "ru", "zh"],
+      "required": ["en", "es", "it", "tr", "ru", "zh", "hi", "pl", "ko"],
       "additionalProperties": { "$ref": "#/$defs/steps" }
     },
     "steps": {


### PR DESCRIPTION
## Problem

`data/exercises.schema.json` was added in a081e72, **before** the Hindi (73b0c68) and Polish/Korean (118e4bd) instructions landed. It was never updated, so `languageMap` and `languageStepsMap` still declare only six languages:

```
required: [en, es, it, tr, ru, zh]
```

Meanwhile all 1,324 records ship **nine** languages, and the README documents nine.

Because both maps set `additionalProperties`, `hi` / `pl` / `ko` were accepted but never validated or required — so a record silently missing them still passed validation. The schema couldn't catch the exact regression it exists to catch.

## Change

Declare all nine languages in `properties` and `required` for both `languageMap` and `languageStepsMap`. Data files are untouched.

## Verification

With `jsonschema` (Draft 2020-12), against the real `data/exercises.json`:

| Check | Result |
|---|---|
| 1,324 real records vs. updated schema | **0 errors** |
| Record missing `hi`/`pl`/`ko` vs. **old** schema | 0 errors — *silently accepted* |
| Record missing `hi`/`pl`/`ko` vs. **new** schema | 6 errors — *now caught* |
| `instructions.ru` set to a non-string | still rejected |

No behavior change for consumers already producing complete records; the schema now simply matches what the dataset and README already promise.