### PR TITLE
Fix TypeScript interface and Python example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,8 @@ print(ex["instructions"]["tr"])  # Turkish
 print(ex["instructions"]["ru"])  # Russian
 print(ex["instructions"]["zh"])  # Chinese
 print(ex["instructions"]["hi"])  # Hindi
+print(ex["instructions"]["pl"])  # Polish
+print(ex["instructions"]["ko"])  # Korean
 ```
 
 ### Python — Load with Pandas
@@ -406,12 +408,23 @@ interface Exercise {
     pl: string;
     ko: string;
   };
+  instruction_steps: {
+    en: string[];
+    es: string[];
+    it: string[];
+    tr: string[];
+    ru: string[];
+    zh: string[];
+    hi: string[];
+    pl: string[];
+    ko: string[];
+  };
   muscle_group: string;
   secondary_muscles: string[];
   target: string;
-  media_id: string | null;
-  image: string | null;
-  gif_url: string | null;
+  media_id: string;
+  image: string;
+  gif_url: string;
   attribution: string;
   created_at: string;
 }


### PR DESCRIPTION
Three documentation inaccuracies in the README, all independent. Docs only — no data or schema changes.

### 1. `media_id` / `image` / `gif_url` were typed `string | null`

No record has a null in any of them, and the JSON Schema declares all three **required, non-nullable strings** (`image` and `gif_url` even carry path patterns):

| field | nulls in data | non-empty string | schema type |
|---|---|---|---|
| `media_id` | 0 / 1324 | 1324 / 1324 | `string`, required |
| `image` | 0 / 1324 | 1324 / 1324 | `string`, required |
| `gif_url` | 0 / 1324 | 1324 / 1324 | `string`, required |

The README's own field table already calls them `string`. The optional type only pushed needless null-handling onto consumers. Narrowed to `string`.

### 2. `instruction_steps` was missing from the interface

Every record carries it (1324/1324) and the field table documents it, but the TypeScript type omitted it, so `data[0].instruction_steps` failed to typecheck. Added as `string[]` per language.

### 3. The Python example skipped Polish and Korean

It stopped at Hindi while the JavaScript example immediately below lists all nine. Added the two missing lines.
