### PR TITLE
fix: preserve media metadata in SQL exports

### DIFF
--- a/index.html
+++ b/index.html
@@ -1684,8 +1684,10 @@
   muscle_group      NVARCHAR(100),
   secondary_muscles NVARCHAR(MAX),  -- JSON array stored as string
   target            NVARCHAR(100),
+  media_id          NVARCHAR(50),
   image             NVARCHAR(500),
   gif_url           NVARCHAR(500),
+  attribution       NVARCHAR(255),
   created_at        DATETIME2
 );`,
     postgresql: `CREATE TABLE exercises (
@@ -1706,8 +1708,10 @@
   muscle_group      VARCHAR(100),
   secondary_muscles JSONB,
   target            VARCHAR(100),
+  media_id          VARCHAR(50),
   image             VARCHAR(500),
   gif_url           VARCHAR(500),
+  attribution       VARCHAR(255),
   created_at        TIMESTAMPTZ
 );`,
     mysql: `CREATE TABLE exercises (
@@ -1728,8 +1732,10 @@
   muscle_group      VARCHAR(100),
   secondary_muscles JSON,
   target            VARCHAR(100),
+  media_id          VARCHAR(50),
   image             VARCHAR(500),
   gif_url           VARCHAR(500),
+  attribution       VARCHAR(255),
   created_at        DATETIME
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`,
     sqlite: `CREATE TABLE exercises (
@@ -1750,8 +1756,10 @@
   muscle_group      TEXT,
   secondary_muscles TEXT,  -- JSON array stored as string
   target            TEXT,
+  media_id          TEXT,
   image             TEXT,
   gif_url           TEXT,
+  attribution       TEXT,
   created_at        TEXT
 );`
   };
@@ -1836,12 +1844,14 @@
         escStr(ex.muscle_group, db),
         escStr(muscles, db),
         escStr(ex.target, db),
+        escStr(ex.media_id, db),
         escStr(ex.image, db),
         escStr(ex.gif_url, db),
+        escStr(ex.attribution, db),
         escStr(ex.created_at, db),
       ].join(', ');
 
-      lines.push(`INSERT INTO exercises (id, name, category, body_part, equipment, instructions_en, instructions_es, instructions_it, instructions_tr, instructions_ru, instructions_zh, instructions_hi, instructions_pl, instructions_ko, muscle_group, secondary_muscles, target, image, gif_url, created_at) VALUES (${vals});`);
+      lines.push(`INSERT INTO exercises (id, name, category, body_part, equipment, instructions_en, instructions_es, instructions_it, instructions_tr, instructions_ru, instructions_zh, instructions_hi, instructions_pl, instructions_ko, muscle_group, secondary_muscles, target, media_id, image, gif_url, attribution, created_at) VALUES (${vals});`);
 
       // Batch commits every 50 rows for MSSQL compatibility
       if (db === 'mssql' && (i + 1) % 50 === 0 && i + 1 < exercises.length) {

--- a/setup.html
+++ b/setup.html
@@ -754,8 +754,10 @@ const DB_SQL = {
   muscle_group      NVARCHAR(100),
   secondary_muscles NVARCHAR(MAX),  -- JSON array stored as string
   target            NVARCHAR(100),
+  media_id          NVARCHAR(50),
   image             NVARCHAR(500),
   gif_url           NVARCHAR(500),
+  attribution       NVARCHAR(255),
   created_at        DATETIME2
 );`,
   postgresql: `CREATE TABLE exercises (
@@ -776,8 +778,10 @@ const DB_SQL = {
   muscle_group      VARCHAR(100),
   secondary_muscles JSONB,
   target            VARCHAR(100),
+  media_id          VARCHAR(50),
   image             VARCHAR(500),
   gif_url           VARCHAR(500),
+  attribution       VARCHAR(255),
   created_at        TIMESTAMPTZ
 );`,
   mysql: `CREATE TABLE exercises (
@@ -798,8 +802,10 @@ const DB_SQL = {
   muscle_group      VARCHAR(100),
   secondary_muscles JSON,
   target            VARCHAR(100),
+  media_id          VARCHAR(50),
   image             VARCHAR(500),
   gif_url           VARCHAR(500),
+  attribution       VARCHAR(255),
   created_at        DATETIME
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`,
   sqlite: `CREATE TABLE exercises (
@@ -820,8 +826,10 @@ const DB_SQL = {
   muscle_group      TEXT,
   secondary_muscles TEXT,  -- JSON array stored as string
   target            TEXT,
+  media_id          TEXT,
   image             TEXT,
   gif_url           TEXT,
+  attribution       TEXT,
   created_at        TEXT
 );`
 };
@@ -1401,7 +1409,7 @@ function buildLlmPrompt(fwKey, dbKey) {
 
 ## Dataset Overview
 - 1,324 fitness exercises
-- Fields: id (string, e.g. "0001"), name, category, body_part, equipment, instructions_en (full text), instructions_es (Spanish text), instructions_it (Italian text), instructions_tr (Turkish text), instructions_ru (Russian text), instructions_zh (Chinese text), instructions_hi (Hindi text), instructions_pl (Polish text), instructions_ko (Korean text), instructions_fr (French text), muscle_group, secondary_muscles (JSON array of strings), target, image (relative path like "images/0001.jpg"), gif_url (relative path like "videos/0001.gif"), created_at
+- Fields: id (string, e.g. "0001"), name, category, body_part, equipment, instructions_en (full text), instructions_es (Spanish text), instructions_it (Italian text), instructions_tr (Turkish text), instructions_ru (Russian text), instructions_zh (Chinese text), instructions_hi (Hindi text), instructions_pl (Polish text), instructions_ko (Korean text), instructions_fr (French text), muscle_group, secondary_muscles (JSON array of strings), target, media_id, image (relative path like "images/0001.jpg"), gif_url (relative path like "videos/0001.gif"), attribution (required Gym visual credit), created_at
 
 ## Database Schema (${db.name})
 \`\`\`sql
@@ -1551,12 +1559,14 @@ function buildInserts(exercises, db) {
       escStr(ex.muscle_group, db),
       escStr(muscles, db),
       escStr(ex.target, db),
+      escStr(ex.media_id, db),
       escStr(ex.image, db),
       escStr(ex.gif_url, db),
+      escStr(ex.attribution, db),
       escStr(ex.created_at, db),
     ].join(', ');
 
-    lines.push(`INSERT INTO exercises (id, name, category, body_part, equipment, instructions_en, instructions_es, instructions_it, instructions_tr, instructions_ru, instructions_zh, instructions_hi, instructions_pl, instructions_ko, muscle_group, secondary_muscles, target, image, gif_url, created_at) VALUES (${vals});`);
+    lines.push(`INSERT INTO exercises (id, name, category, body_part, equipment, instructions_en, instructions_es, instructions_it, instructions_tr, instructions_ru, instructions_zh, instructions_hi, instructions_pl, instructions_ko, muscle_group, secondary_muscles, target, media_id, image, gif_url, attribution, created_at) VALUES (${vals});`);
 
     if (db === 'mssql' && (i + 1) % 50 === 0 && i + 1 < exercises.length) {
       lines.push('GO');


### PR DESCRIPTION
## Summary

- Preserve `media_id` and required Gym visual attribution in every generated SQL schema and INSERT statement.
- Apply the fix to both shipped SQL exporters: the standalone setup guide and the embedded browser exporter.
- Include both fields in the generated backend prompt's dataset contract.

## Root cause

The exporters created and populated only 20 columns despite each dataset record carrying `media_id` and attribution. Generated imports silently discarded the original media reference and required credit.

## Checks

- Generated and inspected DDL/INSERT output for MSSQL, PostgreSQL, MySQL, and SQLite in both exporters.
- Imported all 1,324 records into SQLite from each exporter; `media_id` and `attribution` were populated for every row.