### PR TITLE
Include French (fr) column in generated SQL

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -751,6 +751,7 @@ const DB_SQL = {
   instructions_hi   NVARCHAR(MAX),
   instructions_pl   NVARCHAR(MAX),
   instructions_ko   NVARCHAR(MAX),
+  instructions_fr   NVARCHAR(MAX),
   muscle_group      NVARCHAR(100),
   secondary_muscles NVARCHAR(MAX),  -- JSON array stored as string
   target            NVARCHAR(100),
@@ -773,6 +774,7 @@ const DB_SQL = {
   instructions_hi   TEXT,
   instructions_pl   TEXT,
   instructions_ko   TEXT,
+  instructions_fr   TEXT,
   muscle_group      VARCHAR(100),
   secondary_muscles JSONB,
   target            VARCHAR(100),
@@ -795,6 +797,7 @@ const DB_SQL = {
   instructions_hi   TEXT,
   instructions_pl   TEXT,
   instructions_ko   TEXT,
+  instructions_fr   TEXT,
   muscle_group      VARCHAR(100),
   secondary_muscles JSON,
   target            VARCHAR(100),
@@ -817,6 +820,7 @@ const DB_SQL = {
   instructions_hi   TEXT,
   instructions_pl   TEXT,
   instructions_ko   TEXT,
+  instructions_fr   TEXT,
   muscle_group      TEXT,
   secondary_muscles TEXT,  -- JSON array stored as string
   target            TEXT,
@@ -1532,6 +1536,7 @@ function buildInserts(exercises, db) {
     const instrHi = ex.instructions && ex.instructions.hi ? ex.instructions.hi : '';
     const instrPl = ex.instructions && ex.instructions.pl ? ex.instructions.pl : '';
     const instrKo = ex.instructions && ex.instructions.ko ? ex.instructions.ko : '';
+    const instrFr = ex.instructions && ex.instructions.fr ? ex.instructions.fr : '';
 
     const vals = [
       escStr(ex.id, db),
@@ -1548,6 +1553,7 @@ function buildInserts(exercises, db) {
       escStr(instrHi, db),
       escStr(instrPl, db),
       escStr(instrKo, db),
+      escStr(instrFr, db),
       escStr(ex.muscle_group, db),
       escStr(muscles, db),
       escStr(ex.target, db),
@@ -1556,7 +1562,7 @@ function buildInserts(exercises, db) {
       escStr(ex.created_at, db),
     ].join(', ');
 
-    lines.push(`INSERT INTO exercises (id, name, category, body_part, equipment, instructions_en, instructions_es, instructions_it, instructions_tr, instructions_ru, instructions_zh, instructions_hi, instructions_pl, instructions_ko, muscle_group, secondary_muscles, target, image, gif_url, created_at) VALUES (${vals});`);
+    lines.push(`INSERT INTO exercises (id, name, category, body_part, equipment, instructions_en, instructions_es, instructions_it, instructions_tr, instructions_ru, instructions_zh, instructions_hi, instructions_pl, instructions_ko, instructions_fr, muscle_group, secondary_muscles, target, image, gif_url, created_at) VALUES (${vals});`);
 
     if (db === 'mssql' && (i + 1) % 50 === 0 && i + 1 < exercises.length) {
       lines.push('GO');


### PR DESCRIPTION
Adds `instructions_fr` to `CREATE TABLE` (all 4 dialects) and to the `INSERT` column list / value array in both `index.html` and `setup.html`.

The schema requires `fr` and every record ships French text, but the exporters silently dropped it.

Closes #58